### PR TITLE
Configure Dependabot to update Dockerfile dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,13 @@
 version: 2
 updates:
 
+  # Maintain Dockerfile dependencies
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      # Check for updates every week
+      interval: "weekly"
+
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Description
This PR configures Dependabot to update the Docker images used in the Dockerfiles.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build