### PR TITLE
Changes to production Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ WORKDIR /ldap-jwt-auth-run
 
 COPY pyproject.toml ./
 COPY ldap_jwt_auth/ ldap_jwt_auth/
-COPY logs/ logs/
 
 RUN --mount=type=cache,target=/root/.cache \
     set -eux; \

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -27,5 +27,5 @@ RUN set -eux; \
 
 USER ldap-jwt-auth
 
-CMD ["uvicorn", "ldap_jwt_auth.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "ldap_jwt_auth.main:app", "--app-dir", "/ldap-jwt-auth-run", "--host", "0.0.0.0", "--port", "8000"]
 EXPOSE 8000

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -5,7 +5,6 @@ WORKDIR /ldap-jwt-auth-run
 COPY README.md pyproject.toml ./
 # Copy ldap_jwt_auth source files
 COPY ldap_jwt_auth/ ldap_jwt_auth/
-COPY logs/ logs/
 
 RUN set -eux; \
     \
@@ -20,10 +19,7 @@ RUN set -eux; \
     \
     # Create a non-root user to run as \
     addgroup -g 500 -S ldap-jwt-auth; \
-    adduser -S -D -G ldap-jwt-auth -H -u 500 -h /ldap-jwt-auth-run ldap-jwt-auth; \
-    \
-    # Change ownership of logs/ - app will need to write log files to it \
-    chown -R ldap-jwt-auth:ldap-jwt-auth logs/;
+    adduser -S -D -G ldap-jwt-auth -H -u 500 -h /ldap-jwt-auth-run ldap-jwt-auth;
 
 USER ldap-jwt-auth
 

--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ production)!
 
 2. Start the container using the image built and map it to port `8000` locally:
    ```bash
-   docker run -p 8000:8000 --name ldap_jwt_auth_api_container -v ./keys/jwt-key:/ldap-jwt-auth-run/keys/jwt-key -v ./keys/jwt-key.pub:/ldap-jwt-auth-run/keys/jwt-key.pub -v ./ldap_server_certs/cacert.pem:/ldap-jwt-auth-run/ldap_server_certs/cacert.pem -v ./active_usernames.txt:/ldap-jwt-auth-run/active_usernames.txt -v ./logs:/ldap-jwt-auth-run/logs ldap_jwt_auth_api_image
+   docker run -p 8000:8000 --name ldap_jwt_auth_api_container -v ./keys/jwt-key:/ldap-jwt-auth-run/keys/jwt-key -v ./keys/jwt-key.pub:/ldap-jwt-auth-run/keys/jwt-key.pub -v ./ldap_server_certs/cacert.pem:/ldap-jwt-auth-run/ldap_server_certs/cacert.pem -v ./active_usernames.txt:/ldap-jwt-auth-run/active_usernames.txt ldap_jwt_auth_api_image
    ```
    or with values for the environment variables:
    ```bash
-   docker run -p 8000:8000 --name ldap_jwt_auth_api_container --env AUTHENTICATION__ACCESS_TOKEN_VALIDITY_MINUTES=10 -v ./keys/jwt-key:/ldap-jwt-auth-run/keys/jwt-key -v ./keys/jwt-key.pub:/ldap-jwt-auth-run/keys/jwt-key.pub -v ./ldap_server_certs/cacert.pem:/ldap-jwt-auth-run/ldap_server_certs/cacert.pem -v ./active_usernames.txt:/ldap-jwt-auth-run/active_usernames.txt -v ./logs:/ldap-jwt-auth-run/logs ldap_jwt_auth_api_image
+   docker run -p 8000:8000 --name ldap_jwt_auth_api_container --env AUTHENTICATION__ACCESS_TOKEN_VALIDITY_MINUTES=10 -v ./keys/jwt-key:/ldap-jwt-auth-run/keys/jwt-key -v ./keys/jwt-key.pub:/ldap-jwt-auth-run/keys/jwt-key.pub -v ./ldap_server_certs/cacert.pem:/ldap-jwt-auth-run/ldap_server_certs/cacert.pem -v ./active_usernames.txt:/ldap-jwt-auth-run/active_usernames.txt ldap_jwt_auth_api_image
    ```
    The microservice should now be running inside Docker at http://localhost:8000 and its Swagger UI could be accessed
    at http://localhost:8000/docs.
@@ -80,13 +80,7 @@ production)!
 #### Using `Dockerfile.prod`
 Use the `Dockerfile.prod` to run just the application itself in a container. This can be used for production.
 
-1. While in root of the project directory, change the permissions of the `logs` directory so that it is writable by
-   other users. This allows the container to save the application logs to it.
-   ```bash
-   sudo chmod -R 0777 logs/
-   ```
-
-2. Private keys are only readable by the owner. Given that the private key is generated on the host machine and the
+1. Private keys are only readable by the owner. Given that the private key is generated on the host machine and the
    container runs with a different user, it means that the key is not readable by the user in the container because the
    ownership belongs to the user on the host. This can be solved by transferring the ownership to the user in the
    container and setting the permissions.
@@ -95,18 +89,18 @@ Use the `Dockerfile.prod` to run just the application itself in a container. Thi
    sudo chmod 0400 keys/jwt-key
    ```
 
-3. Build an image using the `Dockerfile.prod` from the root of the project directory:
+2. Build an image using the `Dockerfile.prod` from the root of the project directory:
    ```bash
    docker build -f Dockerfile.prod -t ldap_jwt_auth_api_image .
    ```
 
-4. Start the container using the image built and map it to port `8000` locally:
+3. Start the container using the image built and map it to port `8000` locally:
    ```bash
-   docker run -p 8000:8000 --name ldap_jwt_auth_api_container -v ./keys/jwt-key:/ldap-jwt-auth-run/keys/jwt-key -v ./keys/jwt-key.pub:/ldap-jwt-auth-run/keys/jwt-key.pub -v ./ldap_server_certs/cacert.pem:/ldap-jwt-auth-run/ldap_server_certs/cacert.pem -v ./active_usernames.txt:/ldap-jwt-auth-run/active_usernames.txt -v ./logs:/ldap-jwt-auth-run/logs ldap_jwt_auth_api_image
+   docker run -p 8000:8000 --name ldap_jwt_auth_api_container -v ./keys/jwt-key:/ldap-jwt-auth-run/keys/jwt-key -v ./keys/jwt-key.pub:/ldap-jwt-auth-run/keys/jwt-key.pub -v ./ldap_server_certs/cacert.pem:/ldap-jwt-auth-run/ldap_server_certs/cacert.pem -v ./active_usernames.txt:/ldap-jwt-auth-run/active_usernames.txt ldap_jwt_auth_api_image
    ```
    or with values for the environment variables:
    ```bash
-   docker run -p 8000:8000 --name ldap_jwt_auth_api_container --env AUTHENTICATION__ACCESS_TOKEN_VALIDITY_MINUTES=10 -v ./keys/jwt-key:/ldap-jwt-auth-run/keys/jwt-key -v ./keys/jwt-key.pub:/ldap-jwt-auth-run/keys/jwt-key.pub -v ./ldap_server_certs/cacert.pem:/ldap-jwt-auth-run/ldap_server_certs/cacert.pem -v ./active_usernames.txt:/ldap-jwt-auth-run/active_usernames.txt -v ./logs:/ldap-jwt-auth-run/logs ldap_jwt_auth_api_image
+   docker run -p 8000:8000 --name ldap_jwt_auth_api_container --env AUTHENTICATION__ACCESS_TOKEN_VALIDITY_MINUTES=10 -v ./keys/jwt-key:/ldap-jwt-auth-run/keys/jwt-key -v ./keys/jwt-key.pub:/ldap-jwt-auth-run/keys/jwt-key.pub -v ./ldap_server_certs/cacert.pem:/ldap-jwt-auth-run/ldap_server_certs/cacert.pem -v ./active_usernames.txt:/ldap-jwt-auth-run/active_usernames.txt ldap_jwt_auth_api_image
    ```
    The microservice should now be running inside Docker at http://localhost:8000 and its Swagger UI could be accessed
    at http://localhost:8000/docs.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
       - ./ldap_jwt_auth:/ldap-jwt-auth-run/ldap_jwt_auth
       - ./keys:/ldap-jwt-auth-run/keys
       - ./ldap_server_certs/cacert.pem:/ldap-jwt-auth-run/ldap_server_certs/cacert.pem
-      - ./logs:/ldap-jwt-auth-run/logs
       - ./active_usernames.txt:/ldap-jwt-auth-run/active_usernames.txt
     ports:
       - 8000:8000

--- a/ldap_jwt_auth/logging.example.ini
+++ b/ldap_jwt_auth/logging.example.ini
@@ -2,35 +2,27 @@
 keys=root,uvicorn.access
 
 [handlers]
-keys=fileHandler,consoleHandler
+keys=consoleHandler
 
 [formatters]
-keys=fileFormatter,consoleFormatter
+keys=consoleFormatter
 
 [logger_root]
 level=DEBUG
-handlers=fileHandler,consoleHandler
+handlers=consoleHandler
 qualname=root
 propagate=0
 
 [logger_uvicorn.access]
 level=INFO
-handlers=fileHandler,consoleHandler
+handlers=consoleHandler
 qualname=uvicorn.access
 propagate=0
-
-[handler_fileHandler]
-class=logging.handlers.TimedRotatingFileHandler
-formatter=fileFormatter
-args=('./logs/ldap-jwt-auth.log', 'D', 1, 20,)
 
 [handler_consoleHandler]
 class=StreamHandler
 formatter=consoleFormatter
 args=(sys.stdout,)
-
-[formatter_fileFormatter]
-format=[%(asctime)s]  %(module)s:%(filename)s:%(funcName)s:%(lineno)d  %(levelname)s - %(message)s
 
 [formatter_consoleFormatter]
 class=uvicorn.logging.ColourizedFormatter

--- a/ldap_jwt_auth/logging.example.ini
+++ b/ldap_jwt_auth/logging.example.ini
@@ -25,6 +25,4 @@ formatter=consoleFormatter
 args=(sys.stdout,)
 
 [formatter_consoleFormatter]
-class=uvicorn.logging.ColourizedFormatter
-format={levelprefix}{message}
-style={
+format=[%(asctime)s]  %(module)s:%(filename)s:%(funcName)s:%(lineno)d  %(levelname)s - %(message)s


### PR DESCRIPTION
## Description
This PR fixes the issue reported in #76 so any custom images created using the prod Docker image from Harbor as the base image while being in a different working directory would not result in any issues now. It also addresses #77 so the default logging in the prod Docker image will be to the console.

## Testing instructions
Add a set of instructions describing how the reviewer should test the code
- [x] Review code
- [x] Check Actions build
- [x] Start a container using prod Docker image from this PR and ensure that it logs to the console only by default
- [x] Start a container using the Dockerfile below and ensure that the fix for #76 is working and app logging can be changed to log to file

```Dockerfile
# Use the LDAP JWT Authentication image on Harbor as the base image
FROM harbor.stfc.ac.uk/ldap-jwt-authentication/auth-api:pr-78

WORKDIR /ldap-jwt-auth-run

USER root

RUN set -eux; \
    \
    mkdir logs; \
    \
    # Change ownership of logs/ - app will need to write log files to it \
    chown -R ldap-jwt-auth:ldap-jwt-auth logs/;

WORKDIR /ldap-jwt-auth-run/ldap_jwt_auth

# Copy the custom logging.ini file
COPY --chown=ldap-jwt-auth:ldap-jwt-auth logging.ini ./logging.ini

USER ldap-jwt-auth
```

## Agile board tracking
closes #76 
closes #77 