### PR TITLE
Handle sensitive values

### DIFF
--- a/ldap_jwt_auth/auth/authentication.py
+++ b/ldap_jwt_auth/auth/authentication.py
@@ -34,8 +34,8 @@ class Authentication:
         :raises LDAPServerError: If there is a problem with the LDAP server.
         :raises UserNotActiveError: If the username is not part of the active usernames.
         """
-        username = user_credentials.username
-        password = user_credentials.password
+        username = user_credentials.username.get_secret_value()
+        password = user_credentials.password.get_secret_value()
         logger.info("Authenticating a user")
         logger.debug("Username provided is '%s'", username)
 
@@ -49,7 +49,7 @@ class Authentication:
             # Disable LDAP operations debugging
             ldap.set_option(ldap.OPT_DEBUG_LEVEL, 0)
 
-            connection = ldap.initialize(config.ldap_server.url)
+            connection = ldap.initialize(config.ldap_server.url.get_secret_value())
             # Set version of LDAP in use
             connection.protocol_version = ldap.VERSION3
             if config.ldap_server.certificate_validation is True:
@@ -64,11 +64,11 @@ class Authentication:
             # Force creation of new SSL context (must be last TLS option)
             connection.set_option(ldap.OPT_X_TLS_NEWCTX, 0)
 
-            if not config.ldap_server.url.startswith("ldaps://"):
+            if not config.ldap_server.url.get_secret_value().startswith("ldaps://"):
                 # Upgrade connection to a secure TLS session
                 connection.start_tls_s()
 
-            connection.simple_bind_s(f"{username}@{config.ldap_server.realm}", user_credentials.password)
+            connection.simple_bind_s(f"{username}@{config.ldap_server.realm.get_secret_value()}", password)
             logger.info("Authentication successful")
             connection.unbind()
         except ldap.INVALID_CREDENTIALS as exc:

--- a/ldap_jwt_auth/core/config.py
+++ b/ldap_jwt_auth/core/config.py
@@ -5,7 +5,7 @@ Module for the overall configuration for the application.
 from pathlib import Path
 from typing import List, Optional
 
-from pydantic import BaseModel, Field, SecretStr, field_validator
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator
 from pydantic_core.core_schema import ValidationInfo
 from pydantic_settings import SettingsConfigDict, BaseSettings
 
@@ -46,6 +46,8 @@ class LDAPServerConfig(BaseModel):
     certificate_validation: bool
     ca_certificate_file_path: Optional[str] = Field(default=None, validate_default=True)
 
+    model_config = ConfigDict(hide_input_in_errors=True)
+
     @field_validator("ca_certificate_file_path")
     @classmethod
     def validate_optional_fields(cls, field_value: str, info: ValidationInfo) -> Optional[str]:
@@ -82,7 +84,10 @@ class Config(BaseSettings):
     ldap_server: LDAPServerConfig
 
     model_config = SettingsConfigDict(
-        env_file=Path(__file__).parent.parent / ".env", env_file_encoding="utf-8", env_nested_delimiter="__"
+        env_file=Path(__file__).parent.parent / ".env",
+        env_file_encoding="utf-8",
+        env_nested_delimiter="__",
+        hide_input_in_errors=True,
     )
 
 

--- a/ldap_jwt_auth/core/config.py
+++ b/ldap_jwt_auth/core/config.py
@@ -5,7 +5,7 @@ Module for the overall configuration for the application.
 from pathlib import Path
 from typing import List, Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, SecretStr, field_validator
 from pydantic_core.core_schema import ValidationInfo
 from pydantic_settings import SettingsConfigDict, BaseSettings
 
@@ -41,8 +41,8 @@ class LDAPServerConfig(BaseModel):
     Configuration model for the LDAP server.
     """
 
-    url: str
-    realm: str
+    url: SecretStr
+    realm: SecretStr
     certificate_validation: bool
     ca_certificate_file_path: Optional[str] = Field(default=None, validate_default=True)
 

--- a/ldap_jwt_auth/core/schemas.py
+++ b/ldap_jwt_auth/core/schemas.py
@@ -2,7 +2,7 @@
 Model for defining the API schema models.
 """
 
-from pydantic import BaseModel, SecretStr
+from pydantic import BaseModel, ConfigDict, SecretStr
 
 
 class UserCredentialsPostRequestSchema(BaseModel):
@@ -12,3 +12,5 @@ class UserCredentialsPostRequestSchema(BaseModel):
 
     username: SecretStr
     password: SecretStr
+
+    model_config = ConfigDict(hide_input_in_errors=True)

--- a/ldap_jwt_auth/core/schemas.py
+++ b/ldap_jwt_auth/core/schemas.py
@@ -2,7 +2,7 @@
 Model for defining the API schema models.
 """
 
-from pydantic import BaseModel
+from pydantic import BaseModel, SecretStr
 
 
 class UserCredentialsPostRequestSchema(BaseModel):
@@ -10,5 +10,5 @@ class UserCredentialsPostRequestSchema(BaseModel):
     Model for the user credentials.
     """
 
-    username: str
-    password: str
+    username: SecretStr
+    password: SecretStr

--- a/ldap_jwt_auth/routers/login.py
+++ b/ldap_jwt_auth/routers/login.py
@@ -37,7 +37,7 @@ def login(
     # pylint: disable=missing-function-docstring
     try:
         authentication.authenticate(user_credentials)
-        access_token = jwt_handler.get_access_token(user_credentials.username)
+        access_token = jwt_handler.get_access_token(user_credentials.username.get_secret_value())
         refresh_token = jwt_handler.get_refresh_token()
 
         response = JSONResponse(content=access_token)

--- a/test/unit/auth/test_authentication.py
+++ b/test/unit/auth/test_authentication.py
@@ -32,10 +32,11 @@ def test_authenticate(ldap_initialize_mock):
     user_credentials = UserCredentialsPostRequestSchema(username="username", password="password")
     authentication.authenticate(user_credentials)
 
-    ldap_initialize_mock.assert_called_once_with(config.ldap_server.url)
+    ldap_initialize_mock.assert_called_once_with(config.ldap_server.url.get_secret_value())
     ldap_obj_mock.start_tls_s.assert_called_once()
     ldap_obj_mock.simple_bind_s.assert_called_once_with(
-        f"{user_credentials.username}@{config.ldap_server.realm}", user_credentials.password
+        f"{user_credentials.username.get_secret_value()}@{config.ldap_server.realm.get_secret_value()}",
+        user_credentials.password.get_secret_value(),
     )
     ldap_obj_mock.unbind.assert_called_once()
 
@@ -67,10 +68,11 @@ def test_authenticate_with_invalid_credentials(ldap_initialize_mock):
     with pytest.raises(InvalidCredentialsError) as exc:
         authentication.authenticate(user_credentials)
     assert str(exc.value) == "Invalid username or password"
-    ldap_initialize_mock.assert_called_once_with(config.ldap_server.url)
+    ldap_initialize_mock.assert_called_once_with(config.ldap_server.url.get_secret_value())
     ldap_obj_mock.start_tls_s.assert_called_once()
     ldap_obj_mock.simple_bind_s.assert_called_once_with(
-        f"{user_credentials.username}@{config.ldap_server.realm}", user_credentials.password
+        f"{user_credentials.username.get_secret_value()}@{config.ldap_server.realm.get_secret_value()}",
+        user_credentials.password.get_secret_value(),
     )
     ldap_obj_mock.unbind.assert_called_once()
 
@@ -103,7 +105,7 @@ def test_authenticate_ldap_server_error(ldap_initialize_mock):
     with pytest.raises(LDAPServerError) as exc:
         authentication.authenticate(user_credentials)
     assert str(exc.value) == "Problem with LDAP server"
-    ldap_initialize_mock.assert_called_once_with(config.ldap_server.url)
+    ldap_initialize_mock.assert_called_once_with(config.ldap_server.url.get_secret_value())
     ldap_obj_mock.start_tls_s.assert_called_once()
     ldap_obj_mock.unbind.assert_not_called()
 


### PR DESCRIPTION
## Description
This PR changes the types of the `DatabaseConfig` Pydantic class fields from `str` to `SecretStr`. This means that they will be serialised to ``**********`` when accessing their values, or using `.model_dump()`, `.dict()`, or `.json()` (more info [here](https://docs.pydantic.dev/latest/examples/secrets/)). `get_secret_value()` should be used to access the secret value.

It also sets `hide_input_in_errors` on the models to `True` so that the input values can be hidden when `ValidationError` is raised during the validation.

## Testing instructions
Add a set of instructions describing how the reviewer should test the code
- [x] Review code
- [x] Check Actions build
- [x] Ensure that input values are not part of the error messages and logs (A validation error can be triggered by supplying a wrong type of value for a config or not supplying a value for a mandatory config)
- [x] Ensure that input values to the `/login` endpoint are not part of the error messages and logs (A validation error can be triggered by supplying a wrong type of value or not supplying a value for the `username` or `password` fields)