### PR TITLE
Check username when refreshing access token

### DIFF
--- a/ldap_jwt_auth/auth/jwt_handler.py
+++ b/ldap_jwt_auth/auth/jwt_handler.py
@@ -35,14 +35,16 @@ class JWTHandler:
         }
         return self._pack_jwt(payload)
 
-    def get_refresh_token(self) -> str:
+    def get_refresh_token(self, username: str) -> str:
         """
         Generates a payload and returns a signed JWT refresh token.
+        :param username: The username of the user.
         :return: The signed JWT refresh token.
         """
         logger.info("Getting a refresh token")
         payload = {
-            "exp": datetime.now(timezone.utc) + timedelta(days=config.authentication.refresh_token_validity_days)
+            "username": username,
+            "exp": datetime.now(timezone.utc) + timedelta(days=config.authentication.refresh_token_validity_days),
         }
         return self._pack_jwt(payload)
 

--- a/ldap_jwt_auth/core/exceptions.py
+++ b/ldap_jwt_auth/core/exceptions.py
@@ -37,3 +37,9 @@ class UserNotActiveError(Exception):
     """
     Exception raised when user is not active.
     """
+
+
+class UsernameMismatchError(Exception):
+    """
+    Exception raised when the usernames in the access and refresh tokens do not match.
+    """

--- a/ldap_jwt_auth/routers/login.py
+++ b/ldap_jwt_auth/routers/login.py
@@ -38,7 +38,7 @@ def login(
     try:
         authentication.authenticate(user_credentials)
         access_token = jwt_handler.get_access_token(user_credentials.username.get_secret_value())
-        refresh_token = jwt_handler.get_refresh_token()
+        refresh_token = jwt_handler.get_refresh_token(user_credentials.username.get_secret_value())
 
         response = JSONResponse(content=access_token)
         response.set_cookie(


### PR DESCRIPTION
## Description
Adds the username to the refresh tokens and checks that the usernames in the access and refresh tokens match before refreshing the access token.

## Testing instructions
- [x] Review code
- [x] Check Actions build
- [x] Test refreshing an access token with usernames that are matching and not matching

## Agile board tracking
closes #86 