### PR TITLE
Configure tag type on Metadata action

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -27,6 +27,9 @@ jobs:
         uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
         with:
           images: ${{ secrets.HARBOR_URL }}/auth-api
+          tags: |
+            # minimal
+            type=semver,pattern={{version}}
 
       - name: Build and push Docker image to Harbor
         uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0


### PR DESCRIPTION
## Description
This PR configures the Metadata action to not generate `latest` tags for pre-releases.

## Testing instructions
Add a set of instructions describing how the reviewer should test the code
- [ ] Review code
- [ ] Check Actions build
