### PR TITLE
Configure tag type on Metadata action

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -28,8 +28,10 @@ jobs:
         with:
           images: ${{ secrets.HARBOR_URL }}/auth-api
           tags: |
-            # minimal
             type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+          flavor: |
+            latest=false
 
       - name: Build and push Docker image to Harbor
         uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0


### PR DESCRIPTION
## Description
This PR configures the Metadata action to generate `major.minor` tags and not generate `latest` tag at all.

## Testing instructions
Add a set of instructions describing how the reviewer should test the code
- [ ] Review code
- [ ] Check Actions build