### PR TITLE
Configure Dependabot to do Docker image and GitHub Action updates on multiple branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,25 @@
 version: 2
 updates:
-
-  # Maintain Dockerfile dependencies
+  # Maintain Dockerfile dependencies on the `develop` branch
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: daily
       time: "08:00"
       timezone: "Europe/London"
+    target-branch: "develop"
+    ignore:
+      - dependency-name: "python"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+
+  # Maintain Dockerfile dependencies on the `main` branch
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "08:00"
+      timezone: "Europe/London"
+    target-branch: "main"
     ignore:
       - dependency-name: "python"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,12 +24,26 @@ updates:
       - dependency-name: "python"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
-  # Maintain dependencies for GitHub Actions
+  # Maintain dependencies for GitHub Actions on the `develop` branch
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       # Check for updates every week
       interval: "weekly"
+    target-branch: "develop"
+    # Update multiple dependencies at the same time
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # Maintain dependencies for GitHub Actions on the `main` branch
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates every week
+      interval: "weekly"
+    target-branch: "main"
     # Update multiple dependencies at the same time
     groups:
       github-actions:


### PR DESCRIPTION
## Description
This PR configures Dependabot to maintain Dockerfile and GitHub Actions updates on, both, `develop` and `main`.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build

## Agile board tracking
closes #108 
