### PR TITLE
Merge `develop` into `main`

### DIFF
--- a/.github/workflows/.ci.yml
+++ b/.github/workflows/.ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - develop
 
 permissions:
   contents: read

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "ldap-jwt-auth"
 description = "Python microservice providing user authentication against LDAP server and returning a JSON Web Token"
 readme = "README.md"
 requires-python = ">=3.12"
-version = "0.0.1"
+version = "1.0.0"
 
 dependencies = [
     "cryptography==42.0.8",


### PR DESCRIPTION
## Description
For some reason `main` is not up to date with `develop` after we made the first release and after https://github.com/ral-facilities/ldap-jwt-auth/pull/107 went in. This PR merges `develop` into `main` so that they are up to date.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build