### PR TITLE
Bump cryptography from 42.0.8 to 43.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.12"
 version = "1.0.0"
 
 dependencies = [
-    "cryptography==42.0.8",
+    "cryptography==43.0.1",
     "fastapi[all]==0.111.0",
     "PyJWT==2.8.0",
     "python-ldap==3.4.4",


### PR DESCRIPTION
## Description
Bumps the `cryptography` library to address https://github.com/ral-facilities/ldap-jwt-auth/security/dependabot/2 on `main`.

## Testing instructions
Add a set of instructions describing how the reviewer should test the code
- [ ] Review code
- [ ] Check Actions build