### PR TITLE
Only push docker images when manually requested #171

### DIFF
--- a/.github/workflows/.ci.yml
+++ b/.github/workflows/.ci.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Login to Harbor
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
-          registry: ${{ secrets.HARBOR_URL }}
+          registry: ${{ vars.HARBOR_URL }}
           username: ${{ secrets.HARBOR_USERNAME }}
           password: ${{ secrets.HARBOR_TOKEN }}
 
@@ -105,7 +105,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
-          images: ${{ secrets.HARBOR_URL }}/auth-api
+          images: ${{ vars.HARBOR_URL }}/auth-api
 
       - name: ${{ fromJSON(env.PUSH_DOCKER_IMAGE_TO_HARBOR) && 'Build and push Docker image to Harbor' || 'Build Docker image' }}
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0

--- a/.github/workflows/.ci.yml
+++ b/.github/workflows/.ci.yml
@@ -1,6 +1,11 @@
 name: CI
 on:
   workflow_dispatch:
+    inputs:
+      push-docker-image-to-harbor:
+        description: "Push Docker Image to Harbor"
+        type: boolean
+        default: false
   pull_request:
   push:
     branches:
@@ -83,6 +88,8 @@ jobs:
     needs: [linting, unit-tests]
     name: Docker
     runs-on: ubuntu-latest
+    env:
+      PUSH_DOCKER_IMAGE_TO_HARBOR: ${{ inputs.push-docker-image-to-harbor != null && inputs.push-docker-image-to-harbor || 'false' }}
     steps:
       - name: Check out repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -100,11 +107,11 @@ jobs:
         with:
           images: ${{ secrets.HARBOR_URL }}/auth-api
 
-      - name: Build and push Docker image to Harbor
+      - name: ${{ fromJSON(env.PUSH_DOCKER_IMAGE_TO_HARBOR) && 'Build and push Docker image to Harbor' || 'Build Docker image' }}
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           context: .
           file: ./Dockerfile.prod
-          push: true
+          push: ${{ fromJSON(env.PUSH_DOCKER_IMAGE_TO_HARBOR) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,7 +1,7 @@
 name: Release Build
 on:
   push:
-    tags: 'v*'
+    tags: "v*"
 
 permissions:
   contents: read
@@ -18,7 +18,7 @@ jobs:
       - name: Login to Harbor
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
-          registry: ${{ secrets.HARBOR_URL }}
+          registry: ${{ vars.HARBOR_URL }}
           username: ${{ secrets.HARBOR_USERNAME }}
           password: ${{ secrets.HARBOR_TOKEN }}
 
@@ -26,7 +26,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
-          images: ${{ secrets.HARBOR_URL }}/auth-api
+          images: ${{ vars.HARBOR_URL }}/auth-api
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}


### PR DESCRIPTION
## Description

Replicates Viktor's changes from scigateway-auth and object-storage-api to prevent us from pushing images each time the CI runs, and instead only when manually requested.

Also replicates the changes to the CI to allow dependabot PRs to pass as found in https://github.com/ral-facilities/object-storage-api/pull/131. I have not removed the previous secret as would require the same changes on main for it to still function.

Tested https://github.com/ral-facilities/ldap-jwt-auth/actions/runs/14464495395.

## Testing instructions

- [ ] Review code
- [ ] Check Actions build

## Agile board tracking

Closes #171, Closes #207
