### PR TITLE
Exclude unnecessary modules from test coverage measurement

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,3 +9,4 @@ coverage:
         target: 75
 ignore:
   - "test/"
+  - "ldap_jwt_auth/routers/*" # ignore routers as they are not unit tested

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,9 @@ dev = [
 
 [tool.setuptools]
 packages = ["ldap_jwt_auth"]
+
+[tool.coverage.run]
+omit = [
+    # Exclude routers from coverage measurement as they are not unit tested
+    "ldap_jwt_auth/routers/*"
+]


### PR DESCRIPTION
## Description
Excludes the router modules from the code coverage measurement.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
closes #243 