### PR TITLE
Fix Dependabot update failure for `pyjwt` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "cachetools>=7.1.1",
     "cryptography>=49.0.0",
     "fastapi[all]>=0.138.0",
-    "PyJWT>=2.12.1",
+    "pyjwt>=2.12.1",
     "python-ldap>=3.4.5",
     "requests>=2.33.1",
 ]


### PR DESCRIPTION
## Description
This changes the casing of the `pyjwt` dependency in the `pyproject.toml` file so that it is the same as in the `uv.lock` file to hopefully fix the Dependabot update failure.

## Testing instructions
- [ ] Review code
- [ ] Check Actions build
- [ ] Review changes to test coverage

## Agile board tracking
closes #392 